### PR TITLE
Implement new option which allows setting QR code mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build/
 node_modules/
+
+*.swp

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ QR Code is a registered trademark of
 License
 -------
 Copyright (C) 2013 Tobias Muellerleile <muellerleile@hrz.uni-marburg.de>
+Copyright (C) 2015 Net Oxygen Sàrl <info@netoxygen.ch>
 
 This library is free software; you can redistribute it and/or modify it under
 the terms of the GNU Lesser General Public License as published by the Free

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Usage
 `ecLevel` – error correction level, valid values: EC_L (lowest [default]) –
 EC_M – EC_Q - EC_H (highest)
 
+`mode` – QR code mode, valid values: MODE_NUM (numeral)– MODE_AN (alphanumeric)–
+MODE_8 (8-bit binary [default])- MODE_KANJI (kanji)
+
 `dotSize`* – Size of one ‚dot‘ in pixels, valid values: 1-50
 (default: 3)
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,17 @@
 var qrc = require('bindings')('qrc.node');
 
 // some convenience consts:
+
+// consts for EC level
 qrc.EC_L = 0;
 qrc.EC_M = 1;
 qrc.EC_Q = 2;
 qrc.EC_H = 3;
+
+// consts for mode
+qrc.MODE_NUM   = 0; // numeric
+qrc.MODE_AN    = 1; // alphanumeric
+qrc.MODE_8     = 2; // 8-bit bytes (binary)
+qrc.MODE_KANJI = 3; // Kanji
 
 module.exports = qrc;

--- a/src/qrc.cc
+++ b/src/qrc.cc
@@ -18,311 +18,311 @@ const unsigned int QRC_MAX_SIZE[] = { 2938, 2319, 1655, 1268 };
 const int WHITE = 16777216;
 
 struct Qrc_Params {
-  const char* data;
-  QRecLevel ec_level;
-  int dot_size;
-  int margin;
-  int foreground_color;
-  int background_color;
-  int version;
+	const char* data;
+	QRecLevel ec_level;
+	int dot_size;
+	int margin;
+	int foreground_color;
+	int background_color;
+	int version;
 
-  Qrc_Params(std::string p_data, QRecLevel p_ec_level = QR_ECLEVEL_L,
-          int p_version = 0,
-          int p_dot_size = 3, int p_margin = 4,
-          int p_foreground_color = 0x0, int p_background_color = 0xffffff) {
-    data = new char[p_data.length() + 1];
-    std::strncpy((char*)data, p_data.c_str(), p_data.length() + 1);
-    ec_level = p_ec_level;
-    version = p_version;
-    dot_size = p_dot_size;
-    margin = p_margin;
-    foreground_color = p_foreground_color;
-    background_color = p_background_color;
-  }
+	Qrc_Params(std::string p_data, QRecLevel p_ec_level = QR_ECLEVEL_L,
+			int p_version = 0,
+			int p_dot_size = 3, int p_margin = 4,
+			int p_foreground_color = 0x0, int p_background_color = 0xffffff) {
+		data = new char[p_data.length() + 1];
+		std::strncpy((char*)data, p_data.c_str(), p_data.length() + 1);
+		ec_level = p_ec_level;
+		version = p_version;
+		dot_size = p_dot_size;
+		margin = p_margin;
+		foreground_color = p_foreground_color;
+		background_color = p_background_color;
+	}
 
-  ~Qrc_Params() {
-    delete data;
-  }
+	~Qrc_Params() {
+		delete data;
+	}
 };
 
 struct Qrc_Png_Buffer {
-  char *data;
-  size_t size;
-  Qrc_Png_Buffer() {
-    data = NULL;
-    size = 0;
-  }
-  ~Qrc_Png_Buffer() {
-    if (data) {
-      free(data);
-    }
-  }
+	char *data;
+	size_t size;
+	Qrc_Png_Buffer() {
+		data = NULL;
+		size = 0;
+	}
+	~Qrc_Png_Buffer() {
+		if (data) {
+			free(data);
+		}
+	}
 };
 
 Qrc_Params* ValidateArgs(const Arguments& args) {
-  struct Qrc_Params* params;
+	struct Qrc_Params* params;
 
-  if (args.Length() < 1 || !args[0]->IsString()) {
-    ThrowException(Exception::TypeError(String::New("No source string given")));
-    return NULL;
-  }
-  std::string data(*v8::String::Utf8Value(args[0]));
-  if (data.length() < 1 || data.length() > QRC_MAX_SIZE[0]) {
-    ThrowException(Exception::RangeError(String::New("Source string length out of range")));
-    return NULL;
-  }
-  params = new Qrc_Params(data);
+	if (args.Length() < 1 || !args[0]->IsString()) {
+		ThrowException(Exception::TypeError(String::New("No source string given")));
+		return NULL;
+	}
+	std::string data(*v8::String::Utf8Value(args[0]));
+	if (data.length() < 1 || data.length() > QRC_MAX_SIZE[0]) {
+		ThrowException(Exception::RangeError(String::New("Source string length out of range")));
+		return NULL;
+	}
+	params = new Qrc_Params(data);
 
-  if (args.Length() > 1) {
-    if (!args[1]->IsObject()) {
-      delete params;
-      ThrowException(Exception::TypeError(String::New("Second argument must be an object")));
-      return NULL;
-    }
-    Local<Object> paramsObj = Local<Object>::Cast(args[1]);
-    Local<Value> paramsVersion = paramsObj->Get(String::New("version"));
-    if (!paramsVersion->IsUndefined()) {
-      if (!paramsVersion->IsInt32()) {
-        delete params;
-        ThrowException(Exception::TypeError(String::New("Wrong type for version")));
-        return NULL;
-      } else if (paramsVersion->IntegerValue() < 1 || paramsVersion->IntegerValue() > QRSPEC_VERSION_MAX) {
-        delete params;
-        ThrowException(Exception::RangeError(String::New("Version out of range")));
-        return NULL;
-      } else {
-        params->version = paramsVersion->IntegerValue();
-      }
-    }
-    Local<Value> paramsEcLevel = paramsObj->Get(String::New("ecLevel"));
-    if (!paramsEcLevel->IsUndefined()) {
-      if (!paramsEcLevel->IsInt32()) {
-        delete params;
-        ThrowException(Exception::TypeError(String::New("Wrong type for EC level")));
-        return NULL;
-      } else if (paramsEcLevel->IntegerValue() < QR_ECLEVEL_L || paramsEcLevel->IntegerValue() > QR_ECLEVEL_H) {
-        delete params;
-        ThrowException(Exception::RangeError(String::New("EC level out of range")));
-        return NULL;
-      } else {
-        params->ec_level = (QRecLevel) paramsEcLevel->IntegerValue();
-        if (data.length() > QRC_MAX_SIZE[params->ec_level]) {
-          delete params;
-          ThrowException(Exception::RangeError(String::New("Source string length out of range")));
-          return NULL;
-        }
-      }
-    }
-    Local<Value> paramsDotSize = paramsObj->Get(String::New("dotSize"));
-    if (!paramsDotSize->IsUndefined()) {
-      if (!paramsDotSize->IsInt32()) {
-        delete params;
-        ThrowException(Exception::TypeError(String::New("Wrong type for dot size")));
-        return NULL;
-      } else if (paramsDotSize->IntegerValue() < 1 || paramsDotSize->IntegerValue() > 50) {
-        delete params;
-        ThrowException(Exception::RangeError(String::New("Dot size out of range")));
-        return NULL;
-      } else {
-        params->dot_size = paramsDotSize->IntegerValue();
-      }
-    }
-    Local<Value> paramsMargin = paramsObj->Get(String::New("margin"));
-    if (!paramsMargin->IsUndefined()) {
-      if (!paramsMargin->IsInt32()) {
-        delete params;
-        ThrowException(Exception::TypeError(String::New("Wrong type for margin size")));
-        return NULL;
-      } else if (paramsMargin->IntegerValue() < 0 || paramsMargin->IntegerValue() > 10) {
-        delete params;
-        ThrowException(Exception::RangeError(String::New("Margin size out of range")));
-        return NULL;
-      } else {
-        params->margin = paramsMargin->IntegerValue();
-      }
-    }
-    Local<Value> paramsFgColor = paramsObj->Get(String::New("foregroundColor"));
-    if (!paramsFgColor->IsUndefined()) {
-      if (!paramsFgColor->IsUint32()) {
-        delete params;
-        ThrowException(Exception::TypeError(String::New("Wrong type for foreground color")));
-        return NULL;
-      } else if (paramsFgColor->IntegerValue() < 0 || paramsFgColor->IntegerValue() >= WHITE) {
-        delete params;
-        ThrowException(Exception::RangeError(String::New("Foreground color out of range")));
-        return NULL;
-      } else {
-        params->foreground_color = paramsFgColor->IntegerValue();
-      }
-    }
-    Local<Value> paramsBgColor = paramsObj->Get(String::New("backgroundColor"));
-    if (!paramsBgColor->IsUndefined()) {
-      if (!paramsBgColor->IsUint32()) {
-        delete params;
-        ThrowException(Exception::TypeError(String::New("Wrong type for background color")));
-        return NULL;
-      } else if (paramsBgColor->IntegerValue() < 0 || paramsBgColor->IntegerValue() >= WHITE) {
-        delete params;
-        ThrowException(Exception::RangeError(String::New("Background color out of range")));
-        return NULL;
-      } else {
-        params->background_color = paramsBgColor->IntegerValue();
-      }
-    }
-  }
+	if (args.Length() > 1) {
+		if (!args[1]->IsObject()) {
+			delete params;
+			ThrowException(Exception::TypeError(String::New("Second argument must be an object")));
+			return NULL;
+		}
+		Local<Object> paramsObj = Local<Object>::Cast(args[1]);
+		Local<Value> paramsVersion = paramsObj->Get(String::New("version"));
+		if (!paramsVersion->IsUndefined()) {
+			if (!paramsVersion->IsInt32()) {
+				delete params;
+				ThrowException(Exception::TypeError(String::New("Wrong type for version")));
+				return NULL;
+			} else if (paramsVersion->IntegerValue() < 1 || paramsVersion->IntegerValue() > QRSPEC_VERSION_MAX) {
+				delete params;
+				ThrowException(Exception::RangeError(String::New("Version out of range")));
+				return NULL;
+			} else {
+				params->version = paramsVersion->IntegerValue();
+			}
+		}
+		Local<Value> paramsEcLevel = paramsObj->Get(String::New("ecLevel"));
+		if (!paramsEcLevel->IsUndefined()) {
+			if (!paramsEcLevel->IsInt32()) {
+				delete params;
+				ThrowException(Exception::TypeError(String::New("Wrong type for EC level")));
+				return NULL;
+			} else if (paramsEcLevel->IntegerValue() < QR_ECLEVEL_L || paramsEcLevel->IntegerValue() > QR_ECLEVEL_H) {
+				delete params;
+				ThrowException(Exception::RangeError(String::New("EC level out of range")));
+				return NULL;
+			} else {
+				params->ec_level = (QRecLevel) paramsEcLevel->IntegerValue();
+				if (data.length() > QRC_MAX_SIZE[params->ec_level]) {
+					delete params;
+					ThrowException(Exception::RangeError(String::New("Source string length out of range")));
+					return NULL;
+				}
+			}
+		}
+		Local<Value> paramsDotSize = paramsObj->Get(String::New("dotSize"));
+		if (!paramsDotSize->IsUndefined()) {
+			if (!paramsDotSize->IsInt32()) {
+				delete params;
+				ThrowException(Exception::TypeError(String::New("Wrong type for dot size")));
+				return NULL;
+			} else if (paramsDotSize->IntegerValue() < 1 || paramsDotSize->IntegerValue() > 50) {
+				delete params;
+				ThrowException(Exception::RangeError(String::New("Dot size out of range")));
+				return NULL;
+			} else {
+				params->dot_size = paramsDotSize->IntegerValue();
+			}
+		}
+		Local<Value> paramsMargin = paramsObj->Get(String::New("margin"));
+		if (!paramsMargin->IsUndefined()) {
+			if (!paramsMargin->IsInt32()) {
+				delete params;
+				ThrowException(Exception::TypeError(String::New("Wrong type for margin size")));
+				return NULL;
+			} else if (paramsMargin->IntegerValue() < 0 || paramsMargin->IntegerValue() > 10) {
+				delete params;
+				ThrowException(Exception::RangeError(String::New("Margin size out of range")));
+				return NULL;
+			} else {
+				params->margin = paramsMargin->IntegerValue();
+			}
+		}
+		Local<Value> paramsFgColor = paramsObj->Get(String::New("foregroundColor"));
+		if (!paramsFgColor->IsUndefined()) {
+			if (!paramsFgColor->IsUint32()) {
+				delete params;
+				ThrowException(Exception::TypeError(String::New("Wrong type for foreground color")));
+				return NULL;
+			} else if (paramsFgColor->IntegerValue() < 0 || paramsFgColor->IntegerValue() >= WHITE) {
+				delete params;
+				ThrowException(Exception::RangeError(String::New("Foreground color out of range")));
+				return NULL;
+			} else {
+				params->foreground_color = paramsFgColor->IntegerValue();
+			}
+		}
+		Local<Value> paramsBgColor = paramsObj->Get(String::New("backgroundColor"));
+		if (!paramsBgColor->IsUndefined()) {
+			if (!paramsBgColor->IsUint32()) {
+				delete params;
+				ThrowException(Exception::TypeError(String::New("Wrong type for background color")));
+				return NULL;
+			} else if (paramsBgColor->IntegerValue() < 0 || paramsBgColor->IntegerValue() >= WHITE) {
+				delete params;
+				ThrowException(Exception::RangeError(String::New("Background color out of range")));
+				return NULL;
+			} else {
+				params->background_color = paramsBgColor->IntegerValue();
+			}
+		}
+	}
 
-  return params;
+	return params;
 }
 
 
 QRcode* Encode(Qrc_Params* params) {
-  QRcode* code;
-  code = QRcode_encodeString8bit((const char*)params->data, params->version, params->ec_level);
-  return code;
+	QRcode* code;
+	code = QRcode_encodeString8bit((const char*)params->data, params->version, params->ec_level);
+	return code;
 }
 
 
 Handle<Value> EncodeBuf(const Arguments& args) {
-  HandleScope scope;
-  Local<Object> codeObj = Object::New();
+	HandleScope scope;
+	Local<Object> codeObj = Object::New();
 
-  Qrc_Params* params = ValidateArgs(args);
-  if (!params) {
-    return scope.Close(codeObj);
-  }
+	Qrc_Params* params = ValidateArgs(args);
+	if (!params) {
+		return scope.Close(codeObj);
+	}
 
-  QRcode* code = Encode(params);
-  delete params;
-  if (code) {
-    Local<node::Buffer> buffer = node::Buffer::New((const char*)code->data, code->width * code->width);
-    codeObj->Set(String::NewSymbol("width"), Integer::New(code->width));
-    codeObj->Set(String::NewSymbol("version"), Integer::New(code->version));
-    codeObj->Set(String::NewSymbol("data"), buffer->handle_);
-    QRcode_free(code);
-  }
-  return scope.Close(codeObj);
+	QRcode* code = Encode(params);
+	delete params;
+	if (code) {
+		Local<node::Buffer> buffer = node::Buffer::New((const char*)code->data, code->width * code->width);
+		codeObj->Set(String::NewSymbol("width"), Integer::New(code->width));
+		codeObj->Set(String::NewSymbol("version"), Integer::New(code->version));
+		codeObj->Set(String::NewSymbol("data"), buffer->handle_);
+		QRcode_free(code);
+	}
+	return scope.Close(codeObj);
 }
 
 
 void Qrc_png_write_buffer(png_structp png_ptr, png_bytep data, png_size_t length) {
-  Qrc_Png_Buffer* b = (Qrc_Png_Buffer *)png_get_io_ptr(png_ptr);
-  size_t nsize = b->size + length;
+	Qrc_Png_Buffer* b = (Qrc_Png_Buffer *)png_get_io_ptr(png_ptr);
+	size_t nsize = b->size + length;
 
-  if (b->data) {
-    b->data = (char *)realloc(b->data, nsize);
-  } else {
-    b->data = (char *)malloc(nsize);
-  }
+	if (b->data) {
+		b->data = (char *)realloc(b->data, nsize);
+	} else {
+		b->data = (char *)malloc(nsize);
+	}
 
-  if (!b->data) {
-    png_error(png_ptr, "Write Error");
-  }
+	if (!b->data) {
+		png_error(png_ptr, "Write Error");
+	}
 
-  memcpy(b->data + b->size, data, length);
-  b->size += length;
+	memcpy(b->data + b->size, data, length);
+	b->size += length;
 }
 
 
 Handle<Value> EncodePNG(const Arguments& args) {
-  HandleScope scope;
-  Local<Object> obj = Object::New();
+	HandleScope scope;
+	Local<Object> obj = Object::New();
 
-  Qrc_Params* params = ValidateArgs(args);
-  if (!params) {
-    return scope.Close(obj);
-  }
+	Qrc_Params* params = ValidateArgs(args);
+	if (!params) {
+		return scope.Close(obj);
+	}
 
-  QRcode* code = Encode(params);
+	QRcode* code = Encode(params);
 
-  if (code) {
-    Qrc_Png_Buffer* bp = new Qrc_Png_Buffer();
+	if (code) {
+		Qrc_Png_Buffer* bp = new Qrc_Png_Buffer();
 
-    png_structp png_ptr;
-    png_infop info_ptr;
-    png_colorp png_plte;
+		png_structp png_ptr;
+		png_infop info_ptr;
+		png_colorp png_plte;
 
-    png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING,
-        NULL, NULL, NULL);
-    if (!png_ptr) {
-      delete params;
-      QRcode_free(code);
-      return scope.Close(obj);
-    }
+		png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING,
+				NULL, NULL, NULL);
+		if (!png_ptr) {
+			delete params;
+			QRcode_free(code);
+			return scope.Close(obj);
+		}
 
-    info_ptr = png_create_info_struct(png_ptr);
-    if (!info_ptr) {
-      png_destroy_write_struct(&png_ptr, (png_infopp)NULL);
-      delete params;
-      QRcode_free(code);
-      return scope.Close(obj);
-    }
+		info_ptr = png_create_info_struct(png_ptr);
+		if (!info_ptr) {
+			png_destroy_write_struct(&png_ptr, (png_infopp)NULL);
+			delete params;
+			QRcode_free(code);
+			return scope.Close(obj);
+		}
 
-    if (setjmp(png_jmpbuf(png_ptr))) {
-      png_destroy_write_struct(&png_ptr, &info_ptr);
-      delete params;
-      QRcode_free(code);
-      return scope.Close(obj);
-    }
+		if (setjmp(png_jmpbuf(png_ptr))) {
+			png_destroy_write_struct(&png_ptr, &info_ptr);
+			delete params;
+			QRcode_free(code);
+			return scope.Close(obj);
+		}
 
-    png_set_write_fn(png_ptr, bp, Qrc_png_write_buffer, NULL);
+		png_set_write_fn(png_ptr, bp, Qrc_png_write_buffer, NULL);
 
-    png_plte = (png_colorp) malloc(sizeof(png_color) * 2);
-    png_plte[0].red = params->background_color >> 16 & 0xFF;
-    png_plte[0].green = params->background_color >> 8 & 0xFF;
-    png_plte[0].blue = params->background_color & 0xFF;
-    png_plte[1].red = params->foreground_color >> 16 & 0xFF;
-    png_plte[1].green = params->foreground_color >> 8 & 0xFF;
-    png_plte[1].blue = params->foreground_color & 0xFF;
+		png_plte = (png_colorp) malloc(sizeof(png_color) * 2);
+		png_plte[0].red = params->background_color >> 16 & 0xFF;
+		png_plte[0].green = params->background_color >> 8 & 0xFF;
+		png_plte[0].blue = params->background_color & 0xFF;
+		png_plte[1].red = params->foreground_color >> 16 & 0xFF;
+		png_plte[1].green = params->foreground_color >> 8 & 0xFF;
+		png_plte[1].blue = params->foreground_color & 0xFF;
 
-    png_set_PLTE(png_ptr, info_ptr, png_plte, 2);
+		png_set_PLTE(png_ptr, info_ptr, png_plte, 2);
 
-    png_set_IHDR(png_ptr, info_ptr, (code->width + params->margin * 2) * params->dot_size, (code->width + params->margin * 2) * params->dot_size, 1,
-        PNG_COLOR_TYPE_PALETTE, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT,
-        PNG_FILTER_TYPE_DEFAULT);
+		png_set_IHDR(png_ptr, info_ptr, (code->width + params->margin * 2) * params->dot_size, (code->width + params->margin * 2) * params->dot_size, 1,
+				PNG_COLOR_TYPE_PALETTE, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT,
+				PNG_FILTER_TYPE_DEFAULT);
 
-    png_write_info(png_ptr, info_ptr);
+		png_write_info(png_ptr, info_ptr);
 
-    png_set_packing(png_ptr);
+		png_set_packing(png_ptr);
 
-    unsigned char* row = new unsigned char[(code->width + params->margin * 2) * params->dot_size];
+		unsigned char* row = new unsigned char[(code->width + params->margin * 2) * params->dot_size];
 
-    for (int y = -(params->margin); y < code->width + params->margin; y++) {
-      for (int x = -(params->margin * params->dot_size); x < (code->width + params->margin) * params->dot_size; x += params->dot_size) {
-        for (int d = 0; d < params->dot_size; d++) {
-          if (y < 0 || y > code->width - 1 || x < 0 || x > ((code->width - 1) * params->dot_size)) {
-            row[x + params->margin * params->dot_size + d] = 0;
-          } else {
-            row[x + params->margin * params->dot_size + d] = code->data[y * code->width + x/params->dot_size] << 7;
-          }
-        }
-      }
-      for (int d = 0; d < params->dot_size; d++) {
-        png_write_row(png_ptr, row);
-      }
-    }
+		for (int y = -(params->margin); y < code->width + params->margin; y++) {
+			for (int x = -(params->margin * params->dot_size); x < (code->width + params->margin) * params->dot_size; x += params->dot_size) {
+				for (int d = 0; d < params->dot_size; d++) {
+					if (y < 0 || y > code->width - 1 || x < 0 || x > ((code->width - 1) * params->dot_size)) {
+						row[x + params->margin * params->dot_size + d] = 0;
+					} else {
+						row[x + params->margin * params->dot_size + d] = code->data[y * code->width + x/params->dot_size] << 7;
+					}
+				}
+			}
+			for (int d = 0; d < params->dot_size; d++) {
+				png_write_row(png_ptr, row);
+			}
+		}
 
-    png_write_end(png_ptr, info_ptr);
-    png_destroy_write_struct(&png_ptr, &info_ptr);
+		png_write_end(png_ptr, info_ptr);
+		png_destroy_write_struct(&png_ptr, &info_ptr);
 
-    delete[] row;
-    free(png_plte);
+		delete[] row;
+		free(png_plte);
 
-    Local<node::Buffer> buffer = node::Buffer::New(bp->data, bp->size);
-    obj->Set(String::NewSymbol("width"), Integer::New(code->width));
-    obj->Set(String::NewSymbol("version"), Integer::New(code->version));
-    obj->Set(String::NewSymbol("data"), buffer->handle_);
-    QRcode_free(code);
-    delete bp;
-  }
-  delete params;
-  return scope.Close(obj);
+		Local<node::Buffer> buffer = node::Buffer::New(bp->data, bp->size);
+		obj->Set(String::NewSymbol("width"), Integer::New(code->width));
+		obj->Set(String::NewSymbol("version"), Integer::New(code->version));
+		obj->Set(String::NewSymbol("data"), buffer->handle_);
+		QRcode_free(code);
+		delete bp;
+	}
+	delete params;
+	return scope.Close(obj);
 }
 
 void init(Handle<Object> exports) {
-  exports->Set(String::NewSymbol("encode"),
-      FunctionTemplate::New(EncodeBuf)->GetFunction());
-  exports->Set(String::NewSymbol("encodePng"),
-      FunctionTemplate::New(EncodePNG)->GetFunction());
+	exports->Set(String::NewSymbol("encode"),
+			FunctionTemplate::New(EncodeBuf)->GetFunction());
+	exports->Set(String::NewSymbol("encodePng"),
+			FunctionTemplate::New(EncodePNG)->GetFunction());
 }
 
 NODE_MODULE(qrc, init)

--- a/src/qrc.cc
+++ b/src/qrc.cc
@@ -254,9 +254,11 @@ void Qrc_png_write_buffer(png_structp png_ptr, png_bytep data, png_size_t length
 	Qrc_Png_Buffer *b = (Qrc_Png_Buffer *)png_get_io_ptr(png_ptr);
 	size_t nsize = b->size + length; // FIXME: overflow check anyone?
 
+	char *old = b->data;
 	b->data = (char *)realloc(b->data, nsize);
 
 	if (!b->data) {
+		free(old);
 		png_error(png_ptr, "Write Error");
 	}
 

--- a/src/qrc.cc
+++ b/src/qrc.cc
@@ -252,13 +252,9 @@ Handle<Value> EncodeBuf(const Arguments& args) {
 
 void Qrc_png_write_buffer(png_structp png_ptr, png_bytep data, png_size_t length) {
 	Qrc_Png_Buffer *b = (Qrc_Png_Buffer *)png_get_io_ptr(png_ptr);
-	size_t nsize = b->size + length;
+	size_t nsize = b->size + length; // FIXME: overflow check anyone?
 
-	if (b->data) {
-		b->data = (char *)realloc(b->data, nsize);
-	} else {
-		b->data = (char *)malloc(nsize);
-	}
+	b->data = (char *)realloc(b->data, nsize);
 
 	if (!b->data) {
 		png_error(png_ptr, "Write Error");

--- a/src/qrc.cc
+++ b/src/qrc.cc
@@ -22,7 +22,7 @@ const unsigned int QRC_MAX_SIZE[] = { 2938, 2319, 1655, 1268 };
 const int WHITE = 16777216;
 
 struct Qrc_Params {
-	const unsigned char *data;
+	unsigned char *data;
 	QRecLevel ec_level;
 	QRencodeMode mode;
 	int dot_size;
@@ -36,7 +36,7 @@ struct Qrc_Params {
 			int p_dot_size = 3, int p_margin = 4,
 			int p_foreground_color = 0x0, int p_background_color = 0xffffff) {
 		data = new unsigned char[p_data.length() + 1];
-		std::strncpy((char*)data, p_data.c_str(), p_data.length() + 1);
+		std::strncpy((char *)data, p_data.c_str(), p_data.length() + 1);
 		ec_level = p_ec_level;
 		mode = p_mode;
 		version = p_version;

--- a/src/qrc.cc
+++ b/src/qrc.cc
@@ -59,9 +59,7 @@ struct Qrc_Png_Buffer {
 		size = 0;
 	}
 	~Qrc_Png_Buffer() {
-		if (data) {
-			free(data);
-		}
+		free(data);
 	}
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -56,6 +56,32 @@ suite('Validation of input params', function () {
     );
   });
 
+  test('mode', function () {
+    assert.throws(
+      function () {
+        qrc.encode('TEST', { mode: qrc.MODE_NUM - 1 });
+      },
+      /Mode out of range/
+    );
+    assert.throws(
+      function () {
+        qrc.encode('TEST', { mode: qrc.MODE_KANJI + 1 });
+      },
+      /Mode out of range/
+    );
+    assert.throws(
+      function () {
+        qrc.encode('TEST', { mode: qrc.MODE_NUM + 0.5 });
+      },
+      /Wrong type for mode/
+    );
+    assert.doesNotThrow(
+      function () {
+        qrc.encode('TEST', { mode: qrc.MODE_AN });
+      }
+    );
+  });
+
   test('dot size', function () {
     assert.throws(
       function () {
@@ -219,6 +245,35 @@ suite('Encode to buffer', function () {
       'dc645b387c5c8189bde0606ef5c6d85880d67fbc');
   });
 
+  test('explicitly set mode(NUM)', function() {
+    var act = qrc.encode('1234', { mode: qrc.MODE_NUM });
+    var hash = crypto.createHash('sha1');
+    assert.strictEqual(act.version, 1);
+    assert.strictEqual(act.width, 21);
+    hash.update(act.data);
+    assert.strictEqual(hash.digest('hex'),
+      '3bbb8a9bfa4ba87aa5ed47d95ec4e36b53180498');
+  });
+
+  test('explicitly set mode(AN)', function() {
+    var act = qrc.encode('FOO1234', { mode: qrc.MODE_AN });
+    var hash = crypto.createHash('sha1');
+    assert.strictEqual(act.version, 1);
+    assert.strictEqual(act.width, 21);
+    hash.update(act.data);
+    assert.strictEqual(hash.digest('hex'),
+      'cc92bdbf848fa1a98bf9e22100495ab06f809387');
+  });
+
+  test('explicitly set mode(8)', function() {
+    var act = qrc.encode('FOO1234', { mode: qrc.MODE_8 });
+    var hash = crypto.createHash('sha1');
+    assert.strictEqual(act.version, 1);
+    assert.strictEqual(act.width, 21);
+    hash.update(act.data);
+    assert.strictEqual(hash.digest('hex'),
+      '04ad4388c4dbc311d667d41200f4c4fae441c30f');
+  });
 });
 
 suite('Encode to PNG buffer', function () {
@@ -280,6 +335,36 @@ suite('Encode to PNG buffer', function () {
     hash.update(act.data);
     assert.strictEqual(hash.digest('hex'),
       '907541542df208453ad40e357fa7d9ed98d208ae');
+  });
+
+  test('explicitly set mode(NUM)', function() {
+    var act = qrc.encodePng('1234', { mode: qrc.MODE_NUM });
+    var hash = crypto.createHash('sha1');
+    assert.strictEqual(act.version, 1);
+    assert.strictEqual(act.width, 21);
+    hash.update(act.data);
+    assert.strictEqual(hash.digest('hex'),
+      '5e2862515472cf8a98b1432d5a2da9ae82ce6d9c');
+  });
+
+  test('explicitly set mode(AN)', function() {
+    var act = qrc.encodePng('FOO1234', { mode: qrc.MODE_AN });
+    var hash = crypto.createHash('sha1');
+    assert.strictEqual(act.version, 1);
+    assert.strictEqual(act.width, 21);
+    hash.update(act.data);
+    assert.strictEqual(hash.digest('hex'),
+      '07f6ebca2afc5b5c63b08bbc4f23cf2763465dac');
+  });
+
+  test('explicitly set mode(8)', function() {
+    var act = qrc.encodePng('FOO1234', { mode: qrc.MODE_8 });
+    var hash = crypto.createHash('sha1');
+    assert.strictEqual(act.version, 1);
+    assert.strictEqual(act.width, 21);
+    hash.update(act.data);
+    assert.strictEqual(hash.digest('hex'),
+      '964df950b5b50d7d7fef91bed7f9f5fa7c9d5906');
   });
 
   test('explicitly set dot size', function() {


### PR DESCRIPTION
This PR implements a new option, "mode", which allows to set the encoding mode for the QR code (numeral, alphanumeric, 8-bit binary (default), Kanji).

To implement this change, the `QRcode* Encode(Qrc_Params* params)` method had to be rewritten but the changes are backward compatible and none of the tests are broken.

This PR also includes a re-indentation of the code (it was a bit hard to read the code with the previous indentation) and some correctness fixes, notably around `malloc()`.
